### PR TITLE
fix(win): update postinstall call for generating assets in assets folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "sigver": "docker-compose up -d --no-recreate sigver",
     "build": "ng build --configuration production",
     "postinstall": "run-script-os",
-    "postinstall:win32": "scripts\\get-assets.bat",
+    "postinstall:win32": "cd scripts && get-assets.bat",
     "postinstall:default": "bash scripts/get-assets.sh && ngcc",
     "postbuild": "run-script-os",
     "postbuild:win32": "",


### PR DESCRIPTION
<!-- markdownlint-disable MD036 -->

<!-- markdownlint-disable MD041 -->

**Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Changed the way the postinstall script run on windows.

**What is the current behavior?** (You can also link to an open issue here)
Assets are generated at the root of the folder
**What is the new behavior (if this is a feature change)?**
Assets are generated in src/assets 
